### PR TITLE
Use newtype wrapper for IntMap Arbitrary instance

### DIFF
--- a/graph-core.cabal
+++ b/graph-core.cabal
@@ -22,16 +22,15 @@ library
                        safe >=0.3,
                        deepseq >=1.3,
                        vector >=0.10,
-                       QuickCheck >=2.6,
                        mtl >=2.1
   hs-source-dirs:      src
-  ghc-options: -Wall -fno-warn-orphans
+  ghc-options: -Wall
 
 test-suite graph-core-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      src
   main-is:             Tests.hs
-  other-modules:       Test.NodeManager, Test.Core, Test.Persistence
+  other-modules:       Test.NodeManager, Test.Core, Test.Persistence, Test.Arbitrary
   build-depends:       base >=4.6 && <5,
                        hashable >=1.2,
                        unordered-containers >=0.2,

--- a/src/Data/Core/Graph/NodeManager.hs
+++ b/src/Data/Core/Graph/NodeManager.hs
@@ -16,7 +16,6 @@ where
 import Control.Monad.State.Strict
 import Data.Hashable
 import Data.Maybe
-import Test.QuickCheck (NonNegative(..), Arbitrary(..))
 import qualified Data.HashMap.Strict as HM
 import qualified Data.IntMap.Strict as IM
 import qualified Data.IntSet as IS
@@ -110,6 +109,3 @@ lookupNode i (NodeManager{..}) = IM.lookup i nm_nodeToKey
 
 unsafeLookupNode :: Node -> NodeManager k -> k
 unsafeLookupNode i nm = fromJust $ lookupNode i nm
-
-instance Arbitrary v => Arbitrary (IM.IntMap v) where
-    arbitrary = fmap (IM.fromList . map (\(NonNegative i, x) -> (i, x))) arbitrary

--- a/src/Data/Core/Graph/PureCore.hs
+++ b/src/Data/Core/Graph/PureCore.hs
@@ -18,7 +18,6 @@ import Data.Function (on)
 import Data.Hashable
 import Data.Maybe
 import Data.STRef
-import Test.QuickCheck
 import qualified Data.Foldable as F
 import qualified Data.HashSet as HS
 import qualified Data.IntMap.Strict as IM
@@ -191,13 +190,3 @@ hullFoldImpl adj f initial root =
           else do newAcc <- f acc x
                   let succs = IM.findWithDefault VU.empty x adj
                   go (IS.insert x visited) newAcc (xs ++ VU.toList succs)
-
-instance Arbitrary Graph where
-    arbitrary = frequency [(1, return empty), (20, denseGraph)]
-        where denseGraph =
-                do n <- choose (0, 30::Int)
-                   let nodeList = [1..n]
-                   adj <- forM nodeList $ \i ->
-                            do bits <- vectorOf n arbitrary
-                               return (i, [ x | (x,b) <- zip nodeList bits, b ])
-                   return $ fromAdj adj

--- a/src/Test/Arbitrary.hs
+++ b/src/Test/Arbitrary.hs
@@ -1,0 +1,23 @@
+module Test.Arbitrary where
+
+import Test.QuickCheck
+import Control.Monad (forM)
+import Data.Core.Graph.NodeManager (NodeMap)
+import Data.Core.Graph.PureCore (Graph, empty, fromAdj)
+import qualified Data.IntMap.Strict as IM
+
+
+newtype TestNodeMap v = TestNodeMap(NodeMap v) deriving Show
+
+instance Arbitrary v => Arbitrary (TestNodeMap v) where
+    arbitrary = fmap (TestNodeMap . IM.fromList . map (\(NonNegative i, x) -> (i, x))) arbitrary
+
+instance Arbitrary Graph where
+    arbitrary = frequency [(1, return empty), (20, denseGraph)]
+        where denseGraph =
+                do n <- choose (0, 30::Int)
+                   let nodeList = [1..n]
+                   adj <- forM nodeList $ \i ->
+                            do bits <- vectorOf n arbitrary
+                               return (i, [ x | (x,b) <- zip nodeList bits, b ])
+                   return $ fromAdj adj

--- a/src/Test/Core.hs
+++ b/src/Test/Core.hs
@@ -5,6 +5,7 @@ import Data.Core.Graph.PureCore
 import Data.Core.Graph.NodeManager (Node)
 
 import Control.Monad
+import Test.Arbitrary ()
 import Test.Framework
 import qualified Data.IntSet as IS
 

--- a/src/Test/NodeManager.hs
+++ b/src/Test/NodeManager.hs
@@ -3,6 +3,7 @@ module Test.NodeManager where
 
 import Data.Core.Graph.NodeManager
 
+import Test.Arbitrary
 import Test.Framework
 import Control.Monad.State.Strict
 import qualified Data.IntMap.Strict as IM
@@ -11,8 +12,8 @@ import qualified Data.List as L
 assertConsistent :: StateT (NodeManager Char) IO ()
 assertConsistent = get >>= liftIO . assertEqual True . isConsistent
 
-prop_init :: NodeMap String -> Property
-prop_init m = uniqueValues m && all (>=0) (IM.keys m)
+prop_init :: TestNodeMap String -> Property
+prop_init (TestNodeMap m) = uniqueValues m && all (>=0) (IM.keys m)
         ==> isConsistent new && m == getNodeMap new
     where new = initNodeManager m
           uniqueValues im = IM.size im == length (L.nub $ IM.elems im)

--- a/src/Test/Persistence.hs
+++ b/src/Test/Persistence.hs
@@ -5,10 +5,11 @@ import Data.Core.Graph
 import Data.Core.Graph.NodeManager
 import Data.Core.Graph.Persistence
 
+import Test.Arbitrary
 import Test.Framework
 
-prop_persistence :: NodeMap Char -> Graph -> Bool
-prop_persistence nodeMap graph =
+prop_persistence :: TestNodeMap Char -> Graph -> Bool
+prop_persistence (TestNodeMap nodeMap) graph =
     let nodeMgr = initNodeManager nodeMap
         (nodeMgr', graph') = loadGraph (persistGraph nodeMgr graph)
     in (nodeMgr' == nodeMgr && graph == graph')


### PR DESCRIPTION
This is required because QuickCheck 2.8.2 introduced its own instance
which conflicts with the one defined here. Fixes #3.

Also move QuickCheck code to the test-suite module Test.Arbitrary to
avoid any future QuickCheck dependency issues for those using the library.
